### PR TITLE
Include getopt.h header

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 
 #include "wldbg-private.h"
+#include "getopt.h"
 
 static int
 is_prefix_of(const char *what, const char *src)

--- a/src/passes.c
+++ b/src/passes.c
@@ -36,6 +36,7 @@
 #include "wldbg-private.h"
 #include "util.h"
 #include "wldbg-pass.h"
+#include "getopt.h"
 
 /* hardcoded passes */
 extern struct wldbg_pass wldbg_pass_list;


### PR DESCRIPTION
To prevent errors such as:

getopt.c:55:33: warning: ‘struct wldbg_options’ declared inside parameter list will not be visible outside of this definition or declaration
 set_opt(const char *arg, struct wldbg_options *opts)
                                 ^~~~~~~~~~~~~
getopt.c: In function ‘set_opt’:
getopt.c:68:7: error: dereferencing pointer to incomplete type ‘struct wldbg_options’
   opts->interactive = 1;
       ^~

Signed-off-by: Tomeu Vizoso <tomeu.vizoso@collabora.com>